### PR TITLE
feat: pseudobulk function

### DIFF
--- a/docs/api/preprocessing.md
+++ b/docs/api/preprocessing.md
@@ -10,4 +10,5 @@
 
     strip_barcodes
     find_library_obs
+    pseudobulk
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,9 +14,10 @@ maintainers = [
 authors = [
   { name = "Michaela Mueller" },
 ]
-requires-python = ">=3.12"
+requires-python = ">=3.11"
 classifiers = [
   "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
@@ -93,12 +94,12 @@ scripts.clean = "git clean -fdX -- {args:docs}"
 # Test the lowest and highest supported Python versions with normal deps
 [[tool.hatch.envs.hatch-test.matrix]]
 deps = [ "stable" ]
-python = [ "3.12", "3.14" ]
+python = [ "3.11", "3.13" ]
 
 # Test the newest supported Python version also with pre-release deps
 [[tool.hatch.envs.hatch-test.matrix]]
 deps = [ "pre" ]
-python = [ "3.14" ]
+python = [ "3.13" ]
 
 [tool.hatch.envs.hatch-test]
 dependency-groups = [ "dev", "test" ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,13 +23,13 @@ classifiers = [
   "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-  "anndata>=0.12",
+  "anndata>=0.11",
   "dask",
   "dask-ml",
   "h5py>=1.14.2",
   "leidenalg",
   "numpy<3",
-  "scanpy>=1.12",
+  "scanpy>=1.11",
   "scipy<1.17",
   # for debug logging (referenced from the issue template)
   "session-info2",
@@ -94,7 +94,7 @@ scripts.clean = "git clean -fdX -- {args:docs}"
 # Test the lowest and highest supported Python versions with normal deps
 [[tool.hatch.envs.hatch-test.matrix]]
 deps = [ "stable" ]
-python = [ "3.11", "3.13" ]
+python = [ "3.10", "3.13" ]
 
 # Test the newest supported Python version also with pre-release deps
 [[tool.hatch.envs.hatch-test.matrix]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,9 +14,10 @@ maintainers = [
 authors = [
   { name = "Michaela Mueller" },
 ]
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 classifiers = [
   "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",

--- a/src/scatlastb_utils/io/write.py
+++ b/src/scatlastb_utils/io/write.py
@@ -9,7 +9,7 @@ import numpy as np
 import pandas as pd
 from dask import array as da
 
-from scatlastb_utils.pipeline.misc import dask_compute
+from scatlastb_utils.utils import dask_compute
 
 from .config import ALL_SLOTS, print_flushed
 from .subset_slots import set_mask_per_slot

--- a/src/scatlastb_utils/pipeline/misc.py
+++ b/src/scatlastb_utils/pipeline/misc.py
@@ -1,16 +1,8 @@
 import hashlib
-import types
-import warnings
 
-import anndata as ad
-import numpy as np
 import pandas as pd
-import sparse
-from dask import array as da
-from scipy import sparse as sp
 
 # Re-exported for backwards compatibility — canonical definitions live in utils
-from scatlastb_utils.utils import apply_layers, dask_compute
 
 
 def get_use_gpu(config):
@@ -114,75 +106,6 @@ def ifelse(statement, _if, _else):
         return _if
     else:
         return _else
-
-
-def check_sparse(matrix, sparse_type=None):
-    """Check if a matrix is in sparse format."""
-    if sparse_type is None:
-        sparse_type = (sp.csr_matrix, sp.csc_matrix, ad.abc.CSRDataset, ad.abc.CSCDataset, sparse.COO)
-    elif not isinstance(sparse_type, tuple):
-        sparse_type = (sparse_type,)
-
-    # convert to type for functions
-    sparse_type = [type(x(0)) if isinstance(x, types.FunctionType) else x for x in sparse_type]
-    sparse_type = tuple(sparse_type)
-
-    if isinstance(matrix, da.Array):
-        return isinstance(matrix._meta, sparse_type)
-    return isinstance(matrix, sparse_type)
-
-
-def check_sparse_equal(a: sp.spmatrix, b: sp.spmatrix):
-    """Check if two matrices are equal in sparse format."""
-    a = a if check_sparse(a) else sp.csr_matrix(a)
-    b = b if check_sparse(b) else sp.csr_matrix(b)
-    if a.shape != b.shape:
-        warnings.warn(f"Shape mismatch: {a.shape} != {b.shape}", stacklevel=2)
-    return a.shape == b.shape and (a != b).nnz == 0
-
-
-def ensure_sparse(adata, layers: [str, list] = None, sparse_type=None, **kwargs):
-    """Convert matrices in AnnData object to sparse format.
-
-    This function also deals with Dask arrays, ensuring that the chunks are sparse.
-
-    :param adata: AnnData object
-    :param layers: List of layers to convert, or 'X', 'raw', or 'all' (default is None, which converts 'X', 'raw', and all layers)
-    :param sparse_type: Type of sparse matrix to convert to (default is None, which uses csr_matrix)
-    :param kwargs: Additional arguments passed to the apply_layers function
-    """
-
-    def to_sparse(matrix, sparse_type=None):
-        if sparse_type is None:
-            sparse_type = sp.csr_matrix
-
-        if check_sparse(matrix, sparse_type):
-            return matrix
-        elif isinstance(matrix, da.Array):
-            return matrix.map_blocks(sparse_type, dtype=matrix.dtype)
-        return sparse_type(matrix)
-
-    return apply_layers(adata, func=to_sparse, layers=layers, sparse_type=sparse_type, **kwargs)
-
-
-def ensure_dense(adata: ad.AnnData, layers: [str, list] = None, **kwargs):
-    """Convert sparse matrices in AnnData object to dense format.
-
-    This function also deals with Dask arrays, ensuring that the chunks are dense.
-
-    :param adata: AnnData object
-    :param layers: List of layers to convert, or 'X', 'raw', or 'all' (default is None, which converts 'X', 'raw', and all layers)
-    :param kwargs: Additional arguments passed to the apply_layers function
-    """
-
-    def to_dense(matrix):
-        if isinstance(matrix, da.Array):
-            return matrix.map_blocks(np.array)
-        if check_sparse(matrix):
-            return matrix.toarray()
-        return matrix
-
-    return apply_layers(adata, func=to_dense, layers=layers, **kwargs)
 
 
 def merge(dfs: list, verbose: bool = True, **kwargs):

--- a/src/scatlastb_utils/pp/pseudobulk.py
+++ b/src/scatlastb_utils/pp/pseudobulk.py
@@ -87,6 +87,7 @@ def pseudobulk(
     sep: str = "--",
     group_cols=None,
     min_cells: int = 0,
+    **kwargs,
 ) -> ad.AnnData:
     """Pseudobulk an AnnData object and its metadata.
 
@@ -104,6 +105,8 @@ def pseudobulk(
         List of obs columns to preserve/aggregate; defaults to all.
     min_cells : int, optional
         Minimum cells per group to keep (>=0).
+    kwargs : dict
+        Additional arguments passed to `scanpy.get.aggregate`.
 
     Returns
     -------
@@ -143,7 +146,7 @@ def pseudobulk(
     adata.obs = adata.obs[group_cols].copy()
 
     logging.info(f"Aggregate {value_counts.shape[0]} pseudobulks...")
-    pb_adata = sc.get.aggregate(adata, by=group_key, func=agg)
+    pb_adata = sc.get.aggregate(adata, by=group_key, func=agg, **kwargs)
 
     logging.info(f"Aggregate {adata.obs.shape[1]} metadata columns...")
     obs = _aggregate_obs(adata.obs, group_key, group_order=pb_adata.obs_names)

--- a/src/scatlastb_utils/pp/pseudobulk.py
+++ b/src/scatlastb_utils/pp/pseudobulk.py
@@ -1,3 +1,4 @@
+import importlib
 import logging
 from collections.abc import Iterable, Sequence
 
@@ -195,7 +196,7 @@ def _get_pseudobulk_matrix_dask_legacy(adata, group_key, agg, mask, force_sparse
 
 
 def _get_pseudobulk_matrix(adata, group_key, agg, mask, force_sparse, dtype, use_legacy=False, **kwargs):
-    use_legacy |= sc.__version__ < "1.12"
+    use_legacy |= importlib.metadata.version("scanpy") < "1.12"
     if isinstance(adata.X, da.Array) and use_legacy:
         return _get_pseudobulk_matrix_dask_legacy(adata, group_key, agg, mask, force_sparse, dtype=dtype, **kwargs)
 

--- a/src/scatlastb_utils/pp/pseudobulk.py
+++ b/src/scatlastb_utils/pp/pseudobulk.py
@@ -5,6 +5,9 @@ import anndata as ad
 import numpy as np
 import pandas as pd
 import scanpy as sc
+from dask import array as da
+from dask import config as dask_config
+from scipy import sparse as sp
 
 from scatlastb_utils.utils import ensure_sparse
 
@@ -143,14 +146,71 @@ def _aggregate_obs(
     return df
 
 
+def _get_pseudobulk_matrix_dask_legacy(adata, group_key, agg, mask, force_sparse, dtype=None, **kwargs):
+    def aggregate(x, agg, force_sparse=True, dtype=None):
+        if agg == "sum":
+            result = x.sum(0)
+        elif agg == "mean":
+            result = x.mean(0)
+        else:
+            raise ValueError(f'invalid aggregation method "{agg}"')
+        if force_sparse:
+            return sp.csr_matrix(result, dtype=dtype)
+        return np.asarray(result, dtype=dtype)
+
+    dtype = dtype or np.float32
+
+    if mask is None:
+        X = adata.X
+        group_series = adata.obs[group_key]
+    else:
+        X = adata.X[mask.values]
+        group_series = adata.obs.loc[mask, group_key]
+
+    value_counts = group_series.value_counts(dropna=True)
+    groups = value_counts.index.sort_values()  # sort alphabetically so argsort and chunk_sizes agree
+
+    group_col = pd.Categorical(group_series, categories=groups, ordered=True)
+    sorted_idx = np.argsort(group_col.codes, stable=True)
+    chunk_sizes = tuple(value_counts.reindex(groups).values)
+
+    logging.info(f'Sort and rechunk dask array by "{group_key}"...')
+    with dask_config.set(**{"array.slicing.split_large_chunks": False}):
+        X = X[sorted_idx].rechunk((chunk_sizes, -1))
+        meta = sp.csr_matrix((0, 0), dtype=dtype) if force_sparse else np.empty((0, 0), dtype=dtype)
+        pseudobulks = X.map_blocks(
+            aggregate,
+            agg,
+            force_sparse=force_sparse,
+            dtype=dtype,
+            chunks=((1,) * len(groups), X.shape[1]),
+            meta=meta,
+        )
+    assert pseudobulks.shape[0] == len(groups)
+    return pseudobulks, groups
+
+
+def _get_pseudobulk_matrix(adata, group_key, agg, mask, force_sparse, dtype, use_legacy=False, **kwargs):
+    use_legacy |= sc.__version__ < "1.12"
+    if isinstance(adata.X, da.Array) and use_legacy:
+        return _get_pseudobulk_matrix_dask_legacy(adata, group_key, agg, mask, force_sparse, dtype=dtype, **kwargs)
+
+    pb_adata = sc.get.aggregate(adata, by=group_key, func=agg, mask=mask, axis=0, **kwargs)
+    if force_sparse:
+        pb_adata = ensure_sparse(pb_adata)
+    return pb_adata.layers[agg], pb_adata.obs_names
+
+
 def pseudobulk(
     adata: ad.AnnData,
     group_key: str | Sequence[str],
     agg: str = "sum",
     sep: str = "--",
     group_cols=None,
-    min_cells: int = 0,
-    force_sparse: bool = False,
+    min_cells: int = 2,
+    force_sparse: bool = True,
+    dtype: str | np.dtype = "float32",
+    use_legacy: bool = False,
     **kwargs,
 ) -> ad.AnnData:
     """Pseudobulk an AnnData object and its metadata.
@@ -204,20 +264,17 @@ def pseudobulk(
         logging.info(f"Filtering groups with at least {min_cells} cells...")
         value_counts = value_counts[value_counts >= min_cells]
         mask = adata.obs[group_key].isin(value_counts.index)
+        logging.info(f"Remove {mask.sum()} cells from groups with fewer than {min_cells} cells")
 
     logging.info(f"Aggregate {value_counts.shape[0]} pseudobulks...")
-    pb_adata = sc.get.aggregate(adata, by=group_key, func=agg, mask=mask, axis=0, **kwargs)
-    if force_sparse:
-        pb_adata = ensure_sparse(pb_adata)
+    pseudobulks, groups = _get_pseudobulk_matrix(
+        adata, group_key, agg, mask, force_sparse, dtype, use_legacy=use_legacy, **kwargs
+    )
 
     logging.info(f"Aggregate {len(group_cols)} metadata columns...")
-    obs = _aggregate_obs(adata.obs, group_key, group_order=pb_adata.obs_names, columns=group_cols)
-    obs["n_agg"] = pb_adata.obs["n_obs_aggregated"].values
+    obs = _aggregate_obs(adata.obs, group_key, group_order=groups, columns=group_cols)
+    obs["n_agg"] = value_counts.reindex(groups).fillna(0).astype(int)
     obs = obs[group_cols + ["n_agg"]].copy()  # reorder columns
     logging.debug("Aggregated obs:\n%s", obs)
 
-    return ad.AnnData(
-        X=pb_adata.layers[agg],
-        obs=obs,
-        var=adata.var.copy(),
-    )
+    return ad.AnnData(X=pseudobulks, obs=obs, var=adata.var.copy())

--- a/src/scatlastb_utils/pp/pseudobulk.py
+++ b/src/scatlastb_utils/pp/pseudobulk.py
@@ -6,6 +6,8 @@ import numpy as np
 import pandas as pd
 import scanpy as sc
 
+from scatlastb_utils.utils import ensure_sparse
+
 
 def _categorical_mode(x: pd.Series):
     """Robust mode resolver for categorical-like series.
@@ -87,6 +89,7 @@ def pseudobulk(
     sep: str = "--",
     group_cols=None,
     min_cells: int = 0,
+    force_sparse: bool = False,
     **kwargs,
 ) -> ad.AnnData:
     """Pseudobulk an AnnData object and its metadata.
@@ -147,6 +150,8 @@ def pseudobulk(
 
     logging.info(f"Aggregate {value_counts.shape[0]} pseudobulks...")
     pb_adata = sc.get.aggregate(adata, by=group_key, func=agg, **kwargs)
+    if force_sparse:
+        pb_adata = ensure_sparse(pb_adata)
 
     logging.info(f"Aggregate {adata.obs.shape[1]} metadata columns...")
     obs = _aggregate_obs(adata.obs, group_key, group_order=pb_adata.obs_names)

--- a/src/scatlastb_utils/pp/pseudobulk.py
+++ b/src/scatlastb_utils/pp/pseudobulk.py
@@ -44,8 +44,12 @@ def _aggregate_obs(
     obs: pd.DataFrame,
     group_key: str,
     group_order: Iterable,
+    columns: list | None = None,
 ):
-    obs = obs.copy()
+    if columns is None:
+        columns = obs.columns.tolist()
+
+    obs = obs[columns].copy()
     bool_columns = obs.select_dtypes(include=["bool"]).columns.tolist()
     num_columns = obs.select_dtypes(include=["number"]).columns.tolist()
     cat_columns = obs.select_dtypes(exclude=["number", "bool"]).columns.tolist()
@@ -141,21 +145,23 @@ def pseudobulk(
     group_cols = list(dict.fromkeys(group_cols + [group_key]))
 
     # filter groups with too few cells
+    mask = None
     value_counts = adata.obs[group_key].value_counts(dropna=True)
-    value_counts = value_counts[value_counts >= min_cells]
 
-    # subset data (safe copy)
-    adata = adata[adata.obs[group_key].isin(value_counts.index)].copy()
-    adata.obs = adata.obs[group_cols].copy()
+    if min_cells > 0:
+        logging.info(f"Filtering groups with at least {min_cells} cells...")
+        value_counts = value_counts[value_counts >= min_cells]
+        mask = adata.obs[group_key].isin(value_counts.index)
 
     logging.info(f"Aggregate {value_counts.shape[0]} pseudobulks...")
-    pb_adata = sc.get.aggregate(adata, by=group_key, func=agg, **kwargs)
+    pb_adata = sc.get.aggregate(adata, by=group_key, func=agg, mask=mask, axis=0, **kwargs)
     if force_sparse:
         pb_adata = ensure_sparse(pb_adata)
 
-    logging.info(f"Aggregate {adata.obs.shape[1]} metadata columns...")
-    obs = _aggregate_obs(adata.obs, group_key, group_order=pb_adata.obs_names)
+    logging.info(f"Aggregate {len(group_cols)} metadata columns...")
+    obs = _aggregate_obs(adata.obs, group_key, group_order=pb_adata.obs_names, columns=group_cols)
     obs["n_agg"] = pb_adata.obs["n_obs_aggregated"].values
+    obs = obs[group_cols + ["n_agg"]].copy()  # reorder columns
     logging.debug("Aggregated obs:\n%s", obs)
 
     return ad.AnnData(

--- a/src/scatlastb_utils/pp/pseudobulk.py
+++ b/src/scatlastb_utils/pp/pseudobulk.py
@@ -151,7 +151,7 @@ def _aggregate_obs(
     return df
 
 
-def _get_pseudobulk_matrix_dask_legacy(adata, group_key, agg, mask, force_sparse, dtype=None, **kwargs):
+def _get_pseudobulk_matrix_dask_legacy(adata, group_key, agg, mask, layer, force_sparse, dtype=None, **kwargs):
     def aggregate(x, agg, force_sparse=True, dtype=None):
         if agg == "sum":
             result = x.sum(0)
@@ -165,12 +165,13 @@ def _get_pseudobulk_matrix_dask_legacy(adata, group_key, agg, mask, force_sparse
 
     dtype = dtype or np.float32
 
+    # choose data source (prefer named layer when provided)
+    X = adata.X if layer is None or layer == "X" else adata.layers[layer]
     if mask is None:
-        X = adata.X
         group_series = adata.obs[group_key]
     else:
-        X = adata.X[mask.values]
         group_series = adata.obs.loc[mask, group_key]
+        X = X[mask.values]
 
     value_counts = group_series.value_counts(dropna=True)
     groups = value_counts.index.sort_values()  # sort alphabetically so argsort and chunk_sizes agree
@@ -195,12 +196,14 @@ def _get_pseudobulk_matrix_dask_legacy(adata, group_key, agg, mask, force_sparse
     return pseudobulks, groups
 
 
-def _get_pseudobulk_matrix(adata, group_key, agg, mask, force_sparse, dtype, use_legacy=False, **kwargs):
+def _get_pseudobulk_matrix(adata, group_key, agg, mask, layer, force_sparse, dtype, use_legacy=False, **kwargs):
     use_legacy |= importlib.metadata.version("scanpy") < "1.12"
     if isinstance(adata.X, da.Array) and use_legacy:
-        return _get_pseudobulk_matrix_dask_legacy(adata, group_key, agg, mask, force_sparse, dtype=dtype, **kwargs)
+        return _get_pseudobulk_matrix_dask_legacy(
+            adata, group_key, agg, mask, layer, force_sparse, dtype=dtype, **kwargs
+        )
 
-    pb_adata = sc.get.aggregate(adata, by=group_key, func=agg, mask=mask, axis=0, **kwargs)
+    pb_adata = sc.get.aggregate(adata, by=group_key, func=agg, mask=mask, layer=layer, axis=0, **kwargs)
     if force_sparse:
         pb_adata = ensure_sparse(pb_adata)
     return pb_adata.layers[agg], pb_adata.obs_names
@@ -212,6 +215,7 @@ def pseudobulk(
     agg: str = "sum",
     sep: str = "--",
     group_cols=None,
+    layer: str | None = None,
     min_cells: int = 2,
     force_sparse: bool = True,
     dtype: str | np.dtype = "float32",
@@ -273,7 +277,7 @@ def pseudobulk(
 
     logging.info(f"Aggregate {value_counts.shape[0]} pseudobulks...")
     pseudobulks, groups = _get_pseudobulk_matrix(
-        adata, group_key, agg, mask, force_sparse, dtype, use_legacy=use_legacy, **kwargs
+        adata, group_key, agg, mask, layer, force_sparse, dtype, use_legacy=use_legacy, **kwargs
     )
 
     logging.info(f"Aggregate {len(group_cols)} metadata columns...")

--- a/src/scatlastb_utils/pp/pseudobulk.py
+++ b/src/scatlastb_utils/pp/pseudobulk.py
@@ -1,5 +1,5 @@
 import logging
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 
 import anndata as ad
 import numpy as np
@@ -7,26 +7,35 @@ import pandas as pd
 import scanpy as sc
 
 
-def _categorical_mode(x):
-    n_vals = len(x)
-    n_unique = x.nunique()
+def _categorical_mode(x: pd.Series):
+    """Robust mode resolver for categorical-like series.
 
-    # If all values are unique, just return the first one
+    Handles categorical and non-categorical dtypes and missing values.
+    """
+    # Drop NA for mode calculations
+    x_non_na = x.dropna()
+    if x_non_na.empty:
+        return None
+
+    n_vals = len(x_non_na)
+    n_unique = x_non_na.nunique()
+
+    # If all values are unique, return the first non-NA value
     if n_unique == n_vals:
-        return x.iloc[0]
+        return x_non_na.iloc[0]
 
-    if n_unique / n_vals < 0.8:  # threshold can be tuned
-        codes = x.cat.codes.values
-        # Handle missing values (-1 codes)
+    # If series is categorical, leverage codes for performance
+    if pd.api.types.is_categorical_dtype(x_non_na.dtype):
+        codes = x_non_na.cat.codes.values
         codes = codes[codes >= 0]
         if len(codes) == 0:
             return None
         counts = np.bincount(codes)
-        mode_code = np.argmax(counts)
-        return x.cat.categories[mode_code]
+        mode_code = int(np.argmax(counts))
+        return x_non_na.cat.categories[mode_code]
 
-    # If very high uniqueness ratio, use value_counts (avoid bincount)
-    return x.value_counts().index[0]
+    # Fallback to value_counts for general types
+    return x_non_na.value_counts().index[0]
 
 
 def _aggregate_obs(
@@ -34,11 +43,15 @@ def _aggregate_obs(
     group_key: str,
     group_order: Iterable,
 ):
-    bool_columns = obs.select_dtypes("bool").columns.tolist()
-    num_columns = obs.select_dtypes("number").columns.tolist()
-    cat_columns = obs.select_dtypes(exclude=["number", "bool"]).columns
+    obs = obs.copy()
+    bool_columns = obs.select_dtypes(include=["bool"]).columns.tolist()
+    num_columns = obs.select_dtypes(include=["number"]).columns.tolist()
+    cat_columns = obs.select_dtypes(exclude=["number", "bool"]).columns.tolist()
     cat_columns = [col for col in cat_columns if col != group_key]
-    obs[cat_columns] = obs[cat_columns].astype("category")
+
+    # Cast category-like columns to categorical for aggregation efficiency
+    if cat_columns:
+        obs[cat_columns] = obs[cat_columns].astype("category")
 
     if bool_columns or num_columns or cat_columns:
         g = obs.groupby(group_key, observed=True)
@@ -51,54 +64,94 @@ def _aggregate_obs(
         )
     else:
         df = obs.groupby(group_key, observed=True).first()
-    df[bool_columns] = df[bool_columns] > 0.5  # mode for bool
+
+    if bool_columns:
+        df[bool_columns] = df[bool_columns] > 0.5  # mode for bool
 
     logging.info("Set aggregated metadata order...")
     df = df.loc[group_order]
     df[group_key] = df.index.astype(str)
 
     logging.info("Convert metadata to categorical...")
-    # convert category columns to string
     for col in df.columns:
-        if df[col].dtype.name == "category":
+        if pd.api.types.is_categorical_dtype(df[col].dtype):
             df[col] = df[col].astype(str).astype("category")
 
     return df
 
 
 def pseudobulk(
-    adata,
-    group_key,
-    agg="sum",
-    dtype="float32",
-    sep="--",
+    adata: ad.AnnData,
+    group_key: str | Sequence[str],
+    agg: str = "sum",
+    sep: str = "--",
     group_cols=None,
     min_cells: int = 0,
-):
-    """Pseudobulk an AnnData object by aggregating the expression matrix and metadata according to a group key."""
-    if isinstance(group_key, list):
-        group_keys = group_key
-        group_key = sep.join(group_keys)
-        adata.obs[group_key] = adata.obs[group_keys].astype(str).apply(lambda x: sep.join(x), axis=1)
+) -> ad.AnnData:
+    """Pseudobulk an AnnData object and its metadata.
 
+    Parameters
+    ----------
+    adata : AnnData
+        AnnData to aggregate (not modified in-place).
+    group_key : str or list of str
+        Column name or list of column names in `adata.obs` to group by.
+    agg : str, optional
+        Aggregation function name passed to `scanpy.get.aggregate` (e.g. 'sum').
+    sep : str, optional
+        Separator used when joining multiple group keys into a single group label.
+    group_cols : list of str, optional
+        List of obs columns to preserve/aggregate; defaults to all.
+    min_cells : int, optional
+        Minimum cells per group to keep (>=0).
+
+    Returns
+    -------
+    AnnData
+        Pseudobulked AnnData object with aggregated expression and metadata.
+    """
+    adata = adata.copy()
+
+    # Normalize group_key to a single column name
+    if isinstance(group_key, (list, tuple)) or isinstance(group_key, Sequence) and not isinstance(group_key, str):
+        group_keys = list(group_key)
+        for k in group_keys:
+            if k not in adata.obs.columns:
+                raise KeyError(f"group key '{k}' not found in adata.obs")
+        new_key = sep.join(group_keys)
+        if new_key in adata.obs.columns:
+            raise KeyError(f"generated group key '{new_key}' already exists in adata.obs")
+        adata.obs[new_key] = adata.obs[group_keys].astype(str).apply(lambda x: sep.join(x), axis=1)
+        group_key = new_key
+    else:
+        if group_key not in adata.obs.columns:
+            raise KeyError(f"group key '{group_key}' not found in adata.obs")
+
+    # Determine which obs columns to keep, preserving order
     if group_cols is None:
         group_cols = adata.obs.columns.tolist()
-    group_cols = list(set(group_cols + [group_key]))
+
+    # Ensure group_key present and preserve original order
+    group_cols = list(dict.fromkeys(group_cols + [group_key]))
 
     # filter groups with too few cells
     value_counts = adata.obs[group_key].value_counts(dropna=True)
     value_counts = value_counts[value_counts >= min_cells]
 
-    # subset data
-    adata.obs = adata.obs[group_cols].copy()
+    # subset data (safe copy)
     adata = adata[adata.obs[group_key].isin(value_counts.index)].copy()
+    adata.obs = adata.obs[group_cols].copy()
 
-    logging.info("Aggregate %d pseudobulks...", value_counts.shape[0])
+    logging.info(f"Aggregate {value_counts.shape[0]} pseudobulks...")
     pb_adata = sc.get.aggregate(adata, by=group_key, func=agg)
 
-    logging.info("Aggregate %d metadata columns...", adata.obs.shape[1])
+    logging.info(f"Aggregate {adata.obs.shape[1]} metadata columns...")
     obs = _aggregate_obs(adata.obs, group_key, group_order=pb_adata.obs_names)
-    obs["n_agg"] = pb_adata.obs["n_obs_aggregated"]
+    obs["n_agg"] = pb_adata.obs["n_obs_aggregated"].values
     logging.debug("Aggregated obs:\n%s", obs)
 
-    return ad.AnnData(X=pb_adata.layers[agg].astype(dtype), obs=obs, var=adata.var.copy())
+    return ad.AnnData(
+        X=pb_adata.layers[agg],
+        obs=obs,
+        var=adata.var.copy(),
+    )

--- a/src/scatlastb_utils/pp/pseudobulk.py
+++ b/src/scatlastb_utils/pp/pseudobulk.py
@@ -16,12 +16,23 @@ logging.basicConfig(level=logging.INFO)
 
 
 def _get_group_codes(series: pd.Series, order: Iterable):
-    """Return integer codes for `series` aligned to `order`.
+    """Return integer group codes aligned to `order`.
 
-    Returns a tuple `(codes, n_groups, order_list)` where `codes` is an
-    ndarray of integer group codes (-1 for NA), `n_groups` is the number
-    of groups (len(order_list)), and `order_list` is the list form of
-    `order`.
+    Parameters
+    ----------
+    series : pandas.Series
+        Series of group labels.
+    order : Iterable
+        Desired ordering of groups (categories).
+
+    Returns
+    -------
+    codes : ndarray
+        Integer codes for `series` (same length as `series`), -1 for NA.
+    n_groups : int
+        Number of groups (len of `order`).
+    order_list : list
+        The provided `order` converted to a list.
     """
     order_list = list(order)
     grp = pd.Categorical(series, categories=order_list)
@@ -112,6 +123,29 @@ def _aggregate_obs(
     group_order: Iterable,
     columns: list | None = None,
 ):
+    """Aggregate observation metadata by group.
+
+    Parameters
+    ----------
+    obs : pandas.DataFrame
+        Observation dataframe (typically ``adata.obs``).
+    group_key : str
+        Column name in ``obs`` to group by.
+    group_order : Iterable
+        Ordered list of group labels to use as the result index.
+    columns : list or None
+        Which columns of ``obs`` to aggregate. If ``None``, all columns
+        are used.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Aggregated metadata indexed by ``group_order``. Numeric and
+        boolean columns are averaged, categorical columns use per-group
+        mode, and an ``n_agg`` column with per-group cell counts is
+        added. Categorical dtypes are converted back to categories where
+        possible.
+    """
     if columns is None:
         columns = obs.columns.tolist()
 
@@ -152,6 +186,17 @@ def _aggregate_obs(
 
 
 def _get_pseudobulk_matrix_dask_legacy(adata, group_key, agg, mask, layer, force_sparse, dtype=None, **kwargs):
+    """Aggregate a dask-backed matrix by groups using a legacy path.
+
+    This implementation sorts and rechunks the dask array so that groups
+    are contiguous, then maps a block-wise aggregation function across
+    the grouped chunks.
+
+    Returns a tuple `(pseudobulks, groups)` where `pseudobulks` is a
+    dask array or sparse array (group x features) and `groups` is the
+    ordered list of group labels.
+    """
+
     def aggregate(x, agg, force_sparse=True, dtype=None):
         if agg == "sum":
             result = x.sum(0)
@@ -197,6 +242,19 @@ def _get_pseudobulk_matrix_dask_legacy(adata, group_key, agg, mask, layer, force
 
 
 def _get_pseudobulk_matrix(adata, group_key, agg, mask, layer, force_sparse, dtype, use_legacy=False, **kwargs):
+    """Dispatch to the appropriate pseudobulk matrix implementation.
+
+    Chooses a legacy dask-based implementation when the input is a
+    dask array and `use_legacy` is True (or Scanpy version is older).
+
+    Returns
+    -------
+    matrix : array-like
+        Aggregated matrix (groups x features). May be a dask array or
+        sparse matrix depending on `force_sparse` and backend.
+    groups : Index-like
+        Ordered group labels corresponding to the rows of `matrix`.
+    """
     use_legacy |= importlib.metadata.version("scanpy") < "1.12"
 
     matrix = adata.layers[layer] if layer is not None else adata.X
@@ -224,29 +282,54 @@ def pseudobulk(
     use_legacy: bool = False,
     **kwargs,
 ) -> ad.AnnData:
-    """Pseudobulk an AnnData object and its metadata.
+    """Aggregate an ``AnnData`` object into pseudobulk samples.
 
     Parameters
     ----------
     adata : AnnData
-        AnnData to aggregate (not modified in-place).
-    group_key : str or list of str
-        Column name or list of column names in `adata.obs` to group by.
+        Input annotated data matrix (function works on a copy).
+    group_key : str or sequence of str
+        Column name(s) in ``adata.obs`` to group by. If a sequence is
+        provided the keys are concatenated with ``sep`` to form a single
+        group label column.
     agg : str, optional
-        Aggregation function name passed to `scanpy.get.aggregate` (e.g. 'sum').
+        Aggregation function name forwarded to ``scanpy.get.aggregate``
+        (common values: ``"sum"``, ``"mean"``).
     sep : str, optional
-        Separator used when joining multiple group keys into a single group label.
-    group_cols : list of str, optional
-        List of obs columns to preserve/aggregate; defaults to all.
+        Separator used when joining multiple group keys.
+    group_cols : list-like, optional
+        Which ``adata.obs`` columns to preserve/aggregate. Defaults to
+        all columns.
+    layer : str or None, optional
+        Name of the layer to use for the expression matrix. If ``None``
+        uses ``adata.X``. When provided, both legacy and modern paths
+        prefer the named layer for aggregation.
     min_cells : int, optional
-        Minimum cells per group to keep (>=0).
-    kwargs : dict
-        Additional arguments passed to `scanpy.get.aggregate`.
+        Minimum number of cells required for a group to be kept.
+    force_sparse : bool, optional
+        If True, attempt to return the aggregated matrix in a sparse
+        representation when appropriate.
+    dtype : str or numpy.dtype, optional
+        Data-type to use for aggregation results.
+    use_legacy : bool, optional
+        Force the legacy dask-backed aggregation path when True.
+    **kwargs
+        Forwarded to ``scanpy.get.aggregate``.
 
     Returns
     -------
     AnnData
-        Pseudobulked AnnData object with aggregated expression and metadata.
+        New ``AnnData`` whose ``X`` contains the aggregated matrix
+        (groups x features) and whose ``obs`` contains aggregated
+        metadata (including an ``n_agg`` column with per-group cell
+        counts).
+
+    Notes
+    -----
+    The function filters out groups with fewer than ``min_cells``
+    before aggregation. If multiple ``group_key`` values are provided
+    they are joined using ``sep`` and the combined label is used for
+    grouping.
     """
     adata = adata.copy()
 

--- a/src/scatlastb_utils/pp/pseudobulk.py
+++ b/src/scatlastb_utils/pp/pseudobulk.py
@@ -177,7 +177,7 @@ def _get_pseudobulk_matrix_dask_legacy(adata, group_key, agg, mask, layer, force
     groups = value_counts.index.sort_values()  # sort alphabetically so argsort and chunk_sizes agree
 
     group_col = pd.Categorical(group_series, categories=groups, ordered=True)
-    sorted_idx = np.argsort(group_col.codes, stable=True)
+    sorted_idx = np.argsort(group_col.codes, kind="stable")
     chunk_sizes = tuple(value_counts.reindex(groups).values)
 
     logging.info(f'Sort and rechunk dask array by "{group_key}"...')
@@ -198,7 +198,9 @@ def _get_pseudobulk_matrix_dask_legacy(adata, group_key, agg, mask, layer, force
 
 def _get_pseudobulk_matrix(adata, group_key, agg, mask, layer, force_sparse, dtype, use_legacy=False, **kwargs):
     use_legacy |= importlib.metadata.version("scanpy") < "1.12"
-    if isinstance(adata.X, da.Array) and use_legacy:
+
+    matrix = adata.layers[layer] if layer is not None else adata.X
+    if isinstance(matrix, da.Array) and use_legacy:
         return _get_pseudobulk_matrix_dask_legacy(
             adata, group_key, agg, mask, layer, force_sparse, dtype=dtype, **kwargs
         )

--- a/src/scatlastb_utils/pp/pseudobulk.py
+++ b/src/scatlastb_utils/pp/pseudobulk.py
@@ -138,6 +138,10 @@ def _aggregate_obs(
     df = df.loc[group_order]
     df[group_key] = df.index.astype(str)
 
+    # compute per-group counts (n_agg) and add to aggregated obs
+    counts = obs.groupby(group_key, observed=True).size()
+    df["n_agg"] = counts.reindex(group_order).fillna(0).astype(int)
+
     # Convert metadata to categorical
     for col in df.columns:
         if isinstance(df[col].dtype, pd.CategoricalDtype):
@@ -273,8 +277,6 @@ def pseudobulk(
 
     logging.info(f"Aggregate {len(group_cols)} metadata columns...")
     obs = _aggregate_obs(adata.obs, group_key, group_order=groups, columns=group_cols)
-    obs["n_agg"] = value_counts.reindex(groups).fillna(0).astype(int)
-    obs = obs[group_cols + ["n_agg"]].copy()  # reorder columns
     logging.debug("Aggregated obs:\n%s", obs)
 
     return ad.AnnData(X=pseudobulks, obs=obs, var=adata.var.copy())

--- a/src/scatlastb_utils/pp/pseudobulk.py
+++ b/src/scatlastb_utils/pp/pseudobulk.py
@@ -8,36 +8,98 @@ import scanpy as sc
 
 from scatlastb_utils.utils import ensure_sparse
 
+logging.basicConfig(level=logging.INFO)
 
-def _categorical_mode(x: pd.Series):
-    """Robust mode resolver for categorical-like series.
 
-    Handles categorical and non-categorical dtypes and missing values.
+def _get_group_codes(series: pd.Series, order: Iterable):
+    """Return integer codes for `series` aligned to `order`.
+
+    Returns a tuple `(codes, n_groups, order_list)` where `codes` is an
+    ndarray of integer group codes (-1 for NA), `n_groups` is the number
+    of groups (len(order_list)), and `order_list` is the list form of
+    `order`.
     """
-    # Drop NA for mode calculations
-    x_non_na = x.dropna()
-    if x_non_na.empty:
-        return None
+    order_list = list(order)
+    grp = pd.Categorical(series, categories=order_list)
+    codes = grp.codes.astype(np.int64)
+    n_groups = len(order_list)
+    return codes, n_groups, order_list
 
-    n_vals = len(x_non_na)
-    n_unique = x_non_na.nunique()
 
-    # If all values are unique, return the first non-NA value
-    if n_unique == n_vals:
-        return x_non_na.iloc[0]
+def _mode_for_column(ser: pd.Series, group_codes: np.ndarray, n_groups: int):
+    """Compute per-group categorical mode for one categorical Series.
 
-    # If series is categorical, leverage codes for performance
-    if pd.api.types.is_categorical_dtype(x_non_na.dtype):
-        codes = x_non_na.cat.codes.values
-        codes = codes[codes >= 0]
-        if len(codes) == 0:
-            return None
-        counts = np.bincount(codes)
-        mode_code = int(np.argmax(counts))
-        return x_non_na.cat.categories[mode_code]
+    Packs (group, value) pairs into 64-bit integers, counts unique pairs
+    with np.unique, then selects the most frequent value per group.
+    """
+    ser_cat = ser.astype("category")
+    cat_codes = ser_cat.cat.codes.to_numpy(dtype=np.int64)
 
-    # Fallback to value_counts for general types
-    return x_non_na.value_counts().index[0]
+    valid_mask = (group_codes >= 0) & (cat_codes >= 0)
+    if not valid_mask.any():
+        return np.array([None] * n_groups, dtype=object)
+
+    group_codes_valid = group_codes[valid_mask].astype(np.int64)
+    value_codes_valid = cat_codes[valid_mask]
+
+    # Pack (group, value) into a single int64 for counting
+    packed_keys = (group_codes_valid << 32) | value_codes_valid
+    unique_packed, pair_counts = np.unique(packed_keys, return_counts=True)
+
+    # np.unique returns sorted keys, so group IDs are already in order
+    decoded_group_ids = unique_packed >> 32
+    decoded_value_codes = unique_packed & 0xFFFFFFFF
+
+    # Locate boundaries between groups
+    present_group_ids, start_indices = np.unique(decoded_group_ids, return_index=True)
+    end_indices = np.append(start_indices[1:], decoded_group_ids.size)
+
+    # For each present group pick the value code with the highest count
+    mode_value_codes = np.full(n_groups, -1, dtype=np.int64)
+    for pg, start, end in zip(present_group_ids, start_indices, end_indices, strict=True):
+        seg_counts = pair_counts[start:end]
+        mode_value_codes[pg] = decoded_value_codes[start + seg_counts.argmax()]
+
+    # Map integer codes back to category labels
+    categories = ser_cat.cat.categories
+    mode_values = np.where(mode_value_codes >= 0, categories[mode_value_codes], None)
+    return mode_values
+
+
+def _aggregate_numeric_bool(obs: pd.DataFrame, group_key: str, bool_columns: list, num_columns: list) -> pd.DataFrame:
+    """Aggregate boolean and numeric columns by group (mean).
+
+    Returns an empty DataFrame if no columns provided.
+    """
+    if not (bool_columns or num_columns):
+        return pd.DataFrame()
+    g = obs.groupby(group_key, observed=True)
+    cols = bool_columns + num_columns
+    return g[cols].mean()
+
+
+def _aggregate_categorical(obs: pd.DataFrame, group_key: str, group_order: Iterable, cat_columns: list) -> pd.DataFrame:
+    """Aggregate categorical columns by computing per-group mode for each column.
+
+    Uses `_group_codes` and `_mode_for_column` helpers. Returns a DataFrame
+    indexed by `group_order` with one column per categorical input column.
+    """
+    if not cat_columns:
+        return pd.DataFrame()
+
+    logging.info("Aggregating %d categorical columns...", len(cat_columns))
+    group_codes, n_groups, order_list = _get_group_codes(obs[group_key], group_order)
+    df = pd.DataFrame(index=order_list)
+    for i, col in enumerate(cat_columns, 1):
+        logging.debug("Processing categorical column %d/%d: %s", i, len(cat_columns), col)
+        if obs[col].value_counts().max() == 1:
+            logging.debug("Column '%s' is unique per group, skipping mode calculation", col)
+            modes = obs.groupby(group_key)[col].first().reindex(order_list).values
+        else:
+            modes = _mode_for_column(obs[col], group_codes, n_groups)
+        df[col] = pd.Series(modes, index=order_list)
+
+    return df
 
 
 def _aggregate_obs(
@@ -60,27 +122,22 @@ def _aggregate_obs(
         obs[cat_columns] = obs[cat_columns].astype("category")
 
     if bool_columns or num_columns or cat_columns:
-        g = obs.groupby(group_key, observed=True)
-        df = pd.concat(
-            [
-                g[bool_columns + num_columns].mean(),
-                g[cat_columns].agg(_categorical_mode),
-            ],
-            axis=1,
-        )
+        numeric_cols = _aggregate_numeric_bool(obs, group_key, bool_columns, num_columns)
+        cat_cols = _aggregate_categorical(obs, group_key, group_order, cat_columns)
+        df = pd.concat([numeric_cols, cat_cols], axis=1)
     else:
         df = obs.groupby(group_key, observed=True).first()
 
     if bool_columns:
         df[bool_columns] = df[bool_columns] > 0.5  # mode for bool
 
-    logging.info("Set aggregated metadata order...")
+    # Set aggregated metadata order
     df = df.loc[group_order]
     df[group_key] = df.index.astype(str)
 
-    logging.info("Convert metadata to categorical...")
+    # Convert metadata to categorical
     for col in df.columns:
-        if pd.api.types.is_categorical_dtype(df[col].dtype):
+        if isinstance(df[col].dtype, pd.CategoricalDtype):
             df[col] = df[col].astype(str).astype("category")
 
     return df
@@ -123,19 +180,14 @@ def pseudobulk(
     adata = adata.copy()
 
     # Normalize group_key to a single column name
-    if isinstance(group_key, (list, tuple)) or isinstance(group_key, Sequence) and not isinstance(group_key, str):
+    logging.info(f"Processing group key(s) {group_key}...")
+    if isinstance(group_key, (list, tuple, Sequence)) and not isinstance(group_key, str):
         group_keys = list(group_key)
-        for k in group_keys:
-            if k not in adata.obs.columns:
-                raise KeyError(f"group key '{k}' not found in adata.obs")
-        new_key = sep.join(group_keys)
-        if new_key in adata.obs.columns:
-            raise KeyError(f"generated group key '{new_key}' already exists in adata.obs")
-        adata.obs[new_key] = adata.obs[group_keys].astype(str).apply(lambda x: sep.join(x), axis=1)
-        group_key = new_key
-    else:
-        if group_key not in adata.obs.columns:
-            raise KeyError(f"group key '{group_key}' not found in adata.obs")
+        missing = pd.Index(group_keys).difference(adata.obs.columns)
+        if missing.any():
+            raise KeyError(f"group key(s) {missing.tolist()} not found in adata.obs")
+        group_key = sep.join(group_keys)
+        adata.obs[group_key] = adata.obs[group_keys].astype(str).agg(sep.join, axis=1)
 
     # Determine which obs columns to keep, preserving order
     if group_cols is None:

--- a/src/scatlastb_utils/pp/pseudobulk.py
+++ b/src/scatlastb_utils/pp/pseudobulk.py
@@ -171,6 +171,7 @@ def _aggregate_obs(
 
     # Set aggregated metadata order
     df = df.loc[group_order]
+    df.index.name = None
     df[group_key] = df.index.astype(str)
 
     # compute per-group counts (n_agg) and add to aggregated obs
@@ -234,7 +235,7 @@ def _get_pseudobulk_matrix_dask_legacy(adata, group_key, agg, mask, layer, force
             agg,
             force_sparse=force_sparse,
             dtype=dtype,
-            chunks=((1,) * len(groups), X.shape[1]),
+            chunks=((1,) * len(chunk_sizes), X.shape[1]),
             meta=meta,
         )
     assert pseudobulks.shape[0] == len(groups)

--- a/src/scatlastb_utils/utils.py
+++ b/src/scatlastb_utils/utils.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import logging
+import types
 from contextlib import nullcontext
 
 import anndata as ad
 import numpy as np
 from dask import array as da
+from scipy import sparse as sp
 from tqdm.dask import TqdmCallback
 
 
@@ -131,15 +134,13 @@ def apply_layers(
     for layer in layers:
         if verbose:
             print(f"Apply function {func.__name__} to {layer}...", flush=True)
-        if layer == "X":
+        if layer == "X" and adata.X is not None:
             adata.X = func(adata.X, **kwargs)
         elif layer in adata.layers:
             adata.layers[layer] = func(adata.layers[layer], **kwargs)
         elif layer in adata.obsm:
             adata.obsm[layer] = func(adata.obsm[layer], **kwargs)
-        elif layer == "raw":
-            if adata.raw is None:
-                continue
+        elif layer == "raw" and adata.raw is not None:
             adata_raw = adata.raw.to_adata()
             adata_raw.X = func(adata.raw.X, **kwargs)
             adata.raw = adata_raw
@@ -184,3 +185,72 @@ def dask_compute(
         return x
 
     return apply_layers(adata, func=compute_layer, layers=layers, verbose=verbose, **kwargs)
+
+
+def check_sparse(matrix, sparse_type=None):
+    """Check if a matrix is in sparse format."""
+    if sparse_type is None:
+        sparse_type = (sp.spmatrix, ad.abc.CSRDataset, ad.abc.CSCDataset)
+    elif not isinstance(sparse_type, tuple):
+        sparse_type = (sparse_type,)
+
+    # convert to type for functions
+    sparse_type = [type(x(0)) if isinstance(x, types.FunctionType) else x for x in sparse_type]
+    sparse_type = tuple(sparse_type)
+
+    if isinstance(matrix, da.Array):
+        return isinstance(matrix._meta, sparse_type)
+    return isinstance(matrix, sparse_type)
+
+
+def check_sparse_equal(a: sp.spmatrix, b: sp.spmatrix):
+    """Check if two matrices are equal in sparse format."""
+    a = a if check_sparse(a) else sp.csr_matrix(a)
+    b = b if check_sparse(b) else sp.csr_matrix(b)
+    if a.shape != b.shape:
+        logging.warning(f"Shape mismatch: {a.shape} != {b.shape}")
+    return a.shape == b.shape and (a != b).nnz == 0
+
+
+def ensure_sparse(adata, layers: [str, list] = None, sparse_type=None, **kwargs):
+    """Convert matrices in AnnData object to sparse format.
+
+    This function also deals with Dask arrays, ensuring that the chunks are sparse.
+
+    :param adata: AnnData object
+    :param layers: List of layers to convert, or 'X', 'raw', or 'all' (default is None, which converts 'X', 'raw', and all layers)
+    :param sparse_type: Type of sparse matrix to convert to (default is None, which uses csr_matrix)
+    :param kwargs: Additional arguments passed to the apply_layers function
+    """
+
+    def to_sparse(matrix, sparse_type=None):
+        if sparse_type is None:
+            sparse_type = sp.csr_matrix
+
+        if check_sparse(matrix, sparse_type):
+            return matrix
+        elif isinstance(matrix, da.Array):
+            return matrix.map_blocks(sparse_type, dtype=matrix.dtype)
+        return sparse_type(matrix)
+
+    return apply_layers(adata, func=to_sparse, layers=layers, sparse_type=sparse_type, **kwargs)
+
+
+def ensure_dense(adata: ad.AnnData, layers: [str, list] = None, **kwargs):
+    """Convert sparse matrices in AnnData object to dense format.
+
+    This function also deals with Dask arrays, ensuring that the chunks are dense.
+
+    :param adata: AnnData object
+    :param layers: List of layers to convert, or 'X', 'raw', or 'all' (default is None, which converts 'X', 'raw', and all layers)
+    :param kwargs: Additional arguments passed to the apply_layers function
+    """
+
+    def to_dense(matrix):
+        if isinstance(matrix, da.Array):
+            return matrix.map_blocks(np.array)
+        if check_sparse(matrix):
+            return matrix.toarray()
+        return matrix
+
+    return apply_layers(adata, func=to_dense, layers=layers, **kwargs)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ def adata():
 
     # Parameters for the negative binomial distribution
     n, p = 1000, 0.5
-    counts = sp.csr_matrix(nbinom.rvs(n, p, size=(5, 10)))
+    counts = sp.csr_matrix(nbinom.rvs(n, p, size=(100, 10)))
 
     adata = ad.AnnData(
         X=counts,
@@ -49,3 +49,18 @@ def adata_dask(adata):
     adata.X = da.from_array(adata.X, chunks=(2, -1))
     adata.layers["counts"] = da.from_array(adata.layers["counts"], chunks=(2, -1))
     return adata
+
+
+@pytest.fixture
+def adata_dask_backed(adata):
+    """Write `adata` to a temporary Zarr and yield a dask-backed, backed AnnData."""
+    import tempfile
+    from pathlib import Path
+
+    import scatlastb_utils as sa
+
+    with tempfile.TemporaryDirectory() as td:
+        p = Path(td) / "tmp.zarr"
+        adata.write_zarr(p)
+        adata_dask = sa.io.read_anndata(p, dask=True, backed=True)
+        yield adata_dask

--- a/tests/pp/test_pseudobulk.py
+++ b/tests/pp/test_pseudobulk.py
@@ -25,10 +25,6 @@ def test_aggregate_obs(adata):
     # index should match groups order
     assert list(out.index) == groups
 
-    # n_agg should equal counts per donor
-    expected_counts = adata.obs.groupby("donor_id").size().reindex(groups).values
-    assert list(out["n_agg"].values) == list(expected_counts)
-
     # numeric aggregation: total_counts should match group mean
     expected_total = adata.obs.groupby("donor_id")["total_counts"].mean().reindex(groups)
     for g in groups:

--- a/tests/pp/test_pseudobulk.py
+++ b/tests/pp/test_pseudobulk.py
@@ -1,3 +1,4 @@
+import anndata as ad
 import numpy as np
 import pytest
 import scanpy as sc
@@ -132,3 +133,20 @@ def test_pseudobulk(adata_fixture, use_legacy, layer, request):
         impl="scanpy.get.aggregate",
     )
     assert_allclose_dense(out.X, expected_matrix)
+
+
+def test_pseudobulk_write_file(adata, tmp_path):
+    """Ensure pseudobulk output can be written to HDF5 and Zarr."""
+    out = pseudobulk(adata, group_key="donor_id", agg="sum", use_legacy=False, min_cells=1)
+
+    h5ad_file = tmp_path / "pseudobulk.h5ad"
+    out.write_h5ad(h5ad_file)
+    assert h5ad_file.exists()
+    re_h5 = ad.read_h5ad(h5ad_file)
+    assert re_h5.shape == out.shape
+
+    zarr_dir = tmp_path / "pseudobulk.zarr"
+    out.write_zarr(zarr_dir)
+    assert zarr_dir.exists()
+    re_z = ad.read_zarr(zarr_dir)
+    assert re_z.shape == out.shape

--- a/tests/pp/test_pseudobulk.py
+++ b/tests/pp/test_pseudobulk.py
@@ -1,22 +1,10 @@
 import numpy as np
-import pandas as pd
 import pytest
 import scanpy as sc
 from anndata import AnnData
 from pytest import approx
 
-from scatlastb_utils.pp.pseudobulk import _aggregate_obs, _categorical_mode, pseudobulk
-
-
-@pytest.mark.parametrize(
-    "series,expected",
-    [
-        (pd.Series(["a", "b", "c"]).astype("category"), "a"),
-        (pd.Series(["x", "y", "x", "z"]).astype("category"), "x"),
-    ],
-)
-def test_categorical_mode_param(series, expected):
-    assert _categorical_mode(series) == expected
+from scatlastb_utils.pp.pseudobulk import _aggregate_obs, pseudobulk
 
 
 def test_aggregate_obs(adata):

--- a/tests/pp/test_pseudobulk.py
+++ b/tests/pp/test_pseudobulk.py
@@ -1,10 +1,70 @@
 import numpy as np
 import pytest
 import scanpy as sc
-from anndata import AnnData
-from pytest import approx
 
 from scatlastb_utils.pp.pseudobulk import _aggregate_obs, pseudobulk
+
+
+def _to_dense(x):
+    """Return a dense numpy array for sparse / dask / numpy-like inputs."""
+    # Dask array -> compute
+    if hasattr(x, "compute"):
+        x = x.compute()
+    # scipy sparse -> toarray
+    if hasattr(x, "toarray"):
+        return x.toarray()
+    return np.asarray(x)
+
+
+def assert_allclose_dense(a, b, rtol=1e-6, atol=0, err_msg=None):
+    """Assert that two arrays are equal up to tolerance, with helpful error message.
+
+    Converts inputs to dense arrays first.
+    """
+    ad = _to_dense(a)
+    bd = _to_dense(b)
+    if ad.shape != bd.shape:
+        raise AssertionError(f"shape mismatch: {ad.shape} != {bd.shape}")
+    try:
+        np.testing.assert_allclose(ad, bd, rtol=rtol, atol=atol, err_msg=err_msg)
+    except AssertionError as e:
+        max_abs = np.max(np.abs(ad - bd))
+        max_rel = np.max(np.abs(ad - bd) / (np.abs(bd) + atol)) if np.any(bd) else np.inf
+        raise AssertionError(
+            f"Arrays not equal within rtol={rtol}, atol={atol}. max_abs={max_abs}, max_rel={max_rel}\n{e}"
+        ) from e
+
+
+def _agggregate_brute_force(adata, group_key, groups, agg="sum", layer=None):
+    """Brute-force compute pseudobulk matrix (dense numpy)"""
+    # choose matrix (prefer layer if given) and make dense numpy
+    mat = _to_dense(adata.layers[layer] if layer is not None else adata.X)
+
+    rows = []
+    for g in groups:
+        sub = mat[(adata.obs[group_key] == g).values]
+        if sub.size == 0:
+            rows.append(np.zeros(mat.shape[1], dtype=mat.dtype))
+            continue
+        if agg == "sum":
+            rows.append(np.asarray(sub.sum(axis=0)).ravel())
+        elif agg == "mean":
+            rows.append(np.asarray(sub.mean(axis=0)).ravel())
+        else:
+            raise ValueError(f"unsupported agg: {agg}")
+
+    return np.vstack(rows)
+
+
+def _expected_pseudobulk(adata, groups, group_key, agg="sum", layer=None, impl="brute_force"):
+    mask = adata.obs[group_key].isin(groups).values
+    if impl == "brute_force":
+        adata = adata[mask].copy()
+        return _agggregate_brute_force(adata, group_key, groups, agg=agg, layer=layer)
+
+    pseudobulk = sc.get.aggregate(adata, by=group_key, func=agg, mask=mask, layer=layer, axis=0)
+    pseudobulk = pseudobulk[groups]  # ensure group order matches expected
+    return pseudobulk.layers[agg]
 
 
 def test_aggregate_obs(adata):
@@ -26,52 +86,49 @@ def test_aggregate_obs(adata):
         )
 
 
-@pytest.mark.parametrize("adata_fixture", ["adata", "adata_dask"])
-def test_pseudobulk(adata_fixture, request):
+@pytest.mark.parametrize(
+    "adata_fixture,use_legacy,layer",
+    [
+        ("adata", False, None),
+        ("adata", False, "counts"),
+        ("adata_dask", False, None),
+        ("adata_dask_backed", False, None),
+        ("adata_dask_backed", True, None),
+        ("adata_dask_backed", True, "counts"),
+    ],
+)
+def test_pseudobulk(adata_fixture, use_legacy, layer, request):
     ad = request.getfixturevalue(adata_fixture)
-    groups = sc.get.aggregate(ad, "donor_id", "count_nonzero").obs_names
-    out = pseudobulk(ad, group_key="donor_id", agg="sum")
 
-    # index should match groups order
-    assert all(out.obs_names == groups)
+    # if testing the named-layer case, create the layer and remove X to
+    # replicate the original prefers-layer behaviour
+    if layer is not None:
+        ad.layers["counts"] = ad.X.copy()
+        del ad.X
 
-    # n_agg should equal counts per donor
-    expected_counts = ad.obs.groupby("donor_id").size().reindex(groups).values
-    assert list(out.obs["n_agg"].values) == list(expected_counts)
+    out = pseudobulk(ad, group_key="donor_id", agg="sum", use_legacy=use_legacy, min_cells=1, layer=layer)
 
-    # numeric aggregation: total_counts should match group mean
-    expected_total = ad.obs.groupby("donor_id")["total_counts"].mean().reindex(groups)
-    for g in groups:
-        assert approx(out.obs.loc[g, "total_counts"]) == expected_total.loc[g]
+    # groups should match set of donors (order-insensitive)
+    expected_groups = set(ad.obs["donor_id"].unique())
+    assert set(out.obs_names) == set(expected_groups)
 
+    # matrix aggregation: compute expected using output ordering
+    expected_matrix = _expected_pseudobulk(
+        ad,
+        groups=out.obs_names,
+        group_key="donor_id",
+        agg="sum",
+        layer=layer,
+        impl="brute_force",
+    )
+    assert_allclose_dense(out.X, expected_matrix)
 
-def test_pseudobulk_with_dask_backed_read(adata):
-    import tempfile
-    from pathlib import Path
-
-    import scatlastb_utils as sa
-
-    # use donor_id as group key from fixture
-    groups_list = list(adata.obs["donor_id"].unique())
-
-    with tempfile.TemporaryDirectory() as td:
-        p = Path(td) / "tmp.zarr"
-        adata.write_zarr(p)
-
-        adata_dask = sa.io.read_anndata(p, dask=True, backed=True)
-        print(adata_dask.obs)
-
-        # run pseudobulk, should return an AnnData with one obs per group
-        res = pseudobulk(adata_dask, group_key="donor_id", agg="sum")
-        assert isinstance(res, AnnData)
-        # expected number of pseudobulk samples equals number of unique donors
-        assert res.n_obs == len(groups_list)
-
-
-def test_pseudobulk_prefers_layer(adata):
-    """Ensure pseudobulk uses a named layer created for the aggregation if present."""
-    adata.layers["counts"] = adata.X.copy()  # create a layer to be used for aggregation
-    out = pseudobulk(adata, group_key="donor_id", agg="sum", layer="counts")
-
-    expected = sc.get.aggregate(adata, by="donor_id", func="sum", layer="counts").layers["sum"]
-    assert np.allclose(np.asarray(out.X), expected)
+    expected_matrix = _expected_pseudobulk(
+        ad,
+        groups=out.obs_names,
+        group_key="donor_id",
+        agg="sum",
+        layer=layer,
+        impl="scanpy.get.aggregate",
+    )
+    assert_allclose_dense(out.X, expected_matrix)

--- a/tests/pp/test_pseudobulk.py
+++ b/tests/pp/test_pseudobulk.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pandas as pd
 import pytest
 import scanpy as sc
@@ -71,3 +72,12 @@ def test_pseudobulk_with_dask_backed_read(adata):
         assert isinstance(res, AnnData)
         # expected number of pseudobulk samples equals number of unique donors
         assert res.n_obs == len(groups_list)
+
+
+def test_pseudobulk_prefers_layer(adata):
+    """Ensure pseudobulk uses a named layer created for the aggregation if present."""
+    adata.layers["counts"] = adata.X.copy()  # create a layer to be used for aggregation
+    out = pseudobulk(adata, group_key="donor_id", agg="sum", layer="counts")
+
+    expected = sc.get.aggregate(adata, by="donor_id", func="sum", layer="counts").layers["sum"]
+    assert np.allclose(np.asarray(out.X), expected)

--- a/tests/pp/test_pseudobulk.py
+++ b/tests/pp/test_pseudobulk.py
@@ -14,10 +14,16 @@ def test_aggregate_obs(adata):
     # index should match groups order
     assert list(out.index) == groups
 
-    # numeric aggregation: total_counts should match group mean
-    expected_total = adata.obs.groupby("donor_id")["total_counts"].mean().reindex(groups)
-    for g in groups:
-        assert approx(out.loc[g, "total_counts"]) == expected_total.loc[g]
+    # check obs aggregation: n_agg should match group size, total_counts should match group mean
+    expected_counts = adata.obs.groupby("donor_id").size()
+    expected_total = adata.obs.groupby("donor_id")["total_counts"].mean()
+    for name in groups:
+        assert out.loc[name, "n_agg"] == expected_counts.loc[name], (
+            f"n_agg mismatch for group {name}\n{adata.obs.query('donor_id == @name')}"
+        )
+        assert out.loc[name, "total_counts"] == expected_total.loc[name], (
+            f"total_counts mismatch for group {name}\n{adata.obs.query('donor_id == @name')}"
+        )
 
 
 @pytest.mark.parametrize("adata_fixture", ["adata", "adata_dask"])

--- a/tests/pp/test_pseudobulk.py
+++ b/tests/pp/test_pseudobulk.py
@@ -35,16 +35,13 @@ def assert_allclose_dense(a, b, rtol=1e-6, atol=0, err_msg=None):
         ) from e
 
 
-def _agggregate_brute_force(adata, group_key, groups, agg="sum", layer=None):
+def _agggregate_brute_force(adata, group_key, groups, agg="sum"):
     """Brute-force compute pseudobulk matrix (dense numpy)"""
-    # choose matrix (prefer layer if given) and make dense numpy
-    mat = _to_dense(adata.layers[layer] if layer is not None else adata.X)
-
     rows = []
     for g in groups:
-        sub = mat[(adata.obs[group_key] == g).values]
+        sub = adata.X[(adata.obs[group_key] == g).values]
         if sub.size == 0:
-            rows.append(np.zeros(mat.shape[1], dtype=mat.dtype))
+            rows.append(np.zeros(adata.X.shape[1], dtype=adata.X.dtype))
             continue
         if agg == "sum":
             rows.append(np.asarray(sub.sum(axis=0)).ravel())
@@ -57,12 +54,15 @@ def _agggregate_brute_force(adata, group_key, groups, agg="sum", layer=None):
 
 
 def _expected_pseudobulk(adata, groups, group_key, agg="sum", layer=None, impl="brute_force"):
+    # choose matrix (prefer layer if given) and make dense numpy
+    adata.X = _to_dense(adata.layers[layer] if layer is not None else adata.X)
+
     mask = adata.obs[group_key].isin(groups).values
     if impl == "brute_force":
         adata = adata[mask].copy()
-        return _agggregate_brute_force(adata, group_key, groups, agg=agg, layer=layer)
+        return _agggregate_brute_force(adata, group_key, groups, agg=agg)
 
-    pseudobulk = sc.get.aggregate(adata, by=group_key, func=agg, mask=mask, layer=layer, axis=0)
+    pseudobulk = sc.get.aggregate(adata, by=group_key, func=agg, mask=mask, axis=0)
     pseudobulk = pseudobulk[groups]  # ensure group order matches expected
     return pseudobulk.layers[agg]
 


### PR DESCRIPTION
This pull request introduces several significant changes to improve the pseudobulk functionality and code organization in the `scatlastb_utils` package. The main updates include a comprehensive refactor and enhancement of the `pseudobulk` implementation, migration and consolidation of sparse matrix utilities, and improvements to test fixtures and package configuration for broader compatibility.

**Major changes include:**

### Pseudobulk and Metadata Aggregation Refactor

* The `pseudobulk` function in `src/scatlastb_utils/pp/pseudobulk.py` has been completely refactored for clarity, performance, and flexibility. It now supports robust grouping (including multi-column keys), improved aggregation of categorical, boolean, and numeric metadata, and handles both dense and sparse/dask-backed arrays efficiently. Helper functions for group code management and categorical mode calculation have been added, and the function now returns a fully aggregated `AnnData` object.

### Sparse Matrix Utilities Consolidation

* Sparse matrix utility functions (`check_sparse`, `check_sparse_equal`, `ensure_sparse`, `ensure_dense`, and related helpers) have been moved from `src/scatlastb_utils/pipeline/misc.py` to `src/scatlastb_utils/utils.py` for better modularity and reusability. The implementations have been streamlined and improved. [[1]](diffhunk://#diff-dc0d2febbf94708a0622ae84eea6b58a6d3ffcfd5e46178df572cf56216aa353L2-L13) [[2]](diffhunk://#diff-dc0d2febbf94708a0622ae84eea6b58a6d3ffcfd5e46178df572cf56216aa353L119-L187) [[3]](diffhunk://#diff-13bfb0056882b84ab9a422912ff675ce3746570005f31d7de4308fe668811984R188-R256)
* Corresponding imports have been updated in files such as `src/scatlastb_utils/io/write.py` to reflect the new module locations.

### Package and Test Configuration Improvements

* The Python version requirements and dependencies in `pyproject.toml` have been relaxed and updated for compatibility with Python 3.10 and 3.11, and the test matrix has been adjusted to match the supported versions. Dependency versions for `anndata` and `scanpy` have also been loosened. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L17-R33) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L96-R103)
* Test fixtures in `tests/conftest.py` have been improved: the default test `AnnData` now has more rows (100 instead of 5), and a new fixture `adata_dask_backed` provides a dask-backed, Zarr-backed `AnnData` for more comprehensive testing. [[1]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128L17-R17) [[2]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R52-R66)

### General Code Quality and Robustness

* The `apply_layers` function in `src/scatlastb_utils/utils.py` has been improved to avoid unnecessary operations and handle missing data more gracefully.
* Logging has been added throughout the pseudobulk implementation for better traceability and debugging.

These changes collectively improve the maintainability, performance, and flexibility of the package, especially for users working with large, heterogeneous single-cell datasets.

---

**Change references:**  
- Pseudobulk refactor and aggregation improvements  
- Sparse utilities migration and improvements [[1]](diffhunk://#diff-dc0d2febbf94708a0622ae84eea6b58a6d3ffcfd5e46178df572cf56216aa353L2-L13) [[2]](diffhunk://#diff-dc0d2febbf94708a0622ae84eea6b58a6d3ffcfd5e46178df572cf56216aa353L119-L187) [[3]](diffhunk://#diff-13bfb0056882b84ab9a422912ff675ce3746570005f31d7de4308fe668811984R188-R256) [[4]](diffhunk://#diff-006365d7567d7157faa2f21092146b6af438152b3bcf3ed4d1c4ac82c6f4efc5L12-R12)  
- Package and test configuration updates [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L17-R33) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L96-R103) [[3]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128L17-R17) [[4]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R52-R66)  
- General code quality improvements